### PR TITLE
Remove allocations in the game scene

### DIFF
--- a/Technicolor/HarmonyPatches/TechniLights.cs
+++ b/Technicolor/HarmonyPatches/TechniLights.cs
@@ -12,6 +12,8 @@ namespace Technicolor.HarmonyPatches
     {
         private readonly LightColorizerManager _manager;
         private readonly Config _config;
+        private readonly ILightWithId[] _lights = new ILightWithId[1];
+        private readonly Color?[] _lightColors = new Color?[4];
 
         private TechniLights(LightColorizerManager manager, Config config)
         {
@@ -35,8 +37,10 @@ namespace Technicolor.HarmonyPatches
                 foreach (ILightWithId light in lightColorizer.Lights)
                 {
                     Color color = TechnicolorController.GetTechnicolor(warm, beatmapEventData.time + light.GetHashCode(), _config.TechnicolorLightsStyle);
-                    lightColorizer.Colorize(false, color, color, color, color);
-                    __instance.Refresh(true, new[] { light }, beatmapEventData);
+                    _lights[0] = light;
+                    UpdateLightColors(color);
+                    lightColorizer.Colorize(false, _lightColors);
+                    __instance.Refresh(true, _lights, beatmapEventData);
                 }
 
                 return false;
@@ -50,19 +54,28 @@ namespace Technicolor.HarmonyPatches
 
             {
                 Color color = TechnicolorController.GetTechnicolor(warm, beatmapEventData.time, _config.TechnicolorLightsStyle);
+                UpdateLightColors(color);
                 switch (_config.TechnicolorLightsGrouping)
                 {
                     case TechnicolorLightsGrouping.ISOLATED_GROUP:
-                        lightColorizer.Colorize(false, color, color, color, color);
+                        lightColorizer.Colorize(false, _lightColors);
                         break;
 
                     default:
-                        _manager.GlobalColorize(false, color, color, color, color);
+                        _manager.GlobalColorize(false, _lightColors);
                         break;
                 }
             }
 
             return true;
+        }
+
+        private void UpdateLightColors(Color? color)
+        {
+            _lightColors[0] = color;
+            _lightColors[1] = color;
+            _lightColors[2] = color;
+            _lightColors[3] = color;
         }
     }
 }

--- a/Technicolor/Managers/GradientController.cs
+++ b/Technicolor/Managers/GradientController.cs
@@ -46,6 +46,8 @@ namespace Technicolor.Managers
         private readonly NoteColorizerManager _noteColorizerManager;
         private readonly BombColorizerManager _bombColorizerManager;
         private readonly BackgroundGradientColorizer _backgroundGradientColorizer;
+        private readonly ILightWithId[] _lights = new ILightWithId[1];
+        private readonly Color?[] _lightColors = new Color?[4];
 
         private readonly Color[] _leftSaberPalette = Array.Empty<Color>();
         private readonly Color[] _rightSaberPalette = Array.Empty<Color>();
@@ -219,11 +221,20 @@ namespace Technicolor.Managers
             UpdateTechnicolourEvent?.Invoke();
         }
 
+        private void UpdateLightColors(Color? leftColor, Color? rightColor)
+        {
+            _lightColors[0] = leftColor;
+            _lightColors[1] = rightColor;
+            _lightColors[2] = leftColor;
+            _lightColors[3] = rightColor;
+        }
+
         private void RainbowLights()
         {
             if (_config.TechnicolorLightsGrouping == TechnicolorLightsGrouping.ISOLATED)
             {
-                _lightColorizerManager.GlobalColorize(false, _gradientLeftColor, _gradientRightColor, _gradientLeftColor, _gradientRightColor);
+                UpdateLightColors(_gradientLeftColor, _gradientRightColor);
+                _lightColorizerManager.GlobalColorize(false, _lightColors);
                 foreach (LightColorizer lightColorizer in _lightColorizerManager.Colorizers.Values)
                 {
                     foreach (ILightWithId light in lightColorizer.Lights)
@@ -232,13 +243,16 @@ namespace Technicolor.Managers
                         seed *= 0.001f;
                         Color colorLeft = Color.HSVToRGB(Mathf.Repeat((Time.time * _timeMult) + _mismatchSpeedOffset + seed, 1f), 1f, 1f);
                         Color colorRight = Color.HSVToRGB(Mathf.Repeat((Time.time * _timeMult) + seed, 1f), 1f, 1f);
-                        lightColorizer.Colorize(new[] { light }, colorLeft, colorRight, colorLeft, colorRight);
+                        _lights[0] = light;
+                        UpdateLightColors(colorLeft, colorRight);
+                        lightColorizer.Colorize(_lights, _lightColors);
                     }
                 }
             }
             else
             {
-                _lightColorizerManager.GlobalColorize(true, _gradientLeftColor, _gradientRightColor, _gradientLeftColor, _gradientRightColor);
+                UpdateLightColors(_gradientLeftColor, _gradientRightColor);
+                _lightColorizerManager.GlobalColorize(true, _lightColors);
             }
         }
 


### PR DESCRIPTION
Again some heavy allocations there running on each frame, but there's still some left in Chroma colorizers it looks like. Specifically, the `HashSet` you're using is being allocating an enumerator on each frame. I don't think that `List` does, and I believe it might be better in your situation?